### PR TITLE
Implement rate limiting and Mitigate DoS attacks #16 #17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,22 @@ services:
   web:
     build: ./web
     ports:
-      - "8000:8000"
+      - "8000"
     volumes:
       - ./web:/app
     depends_on:
       - db
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "8000:443"
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./web/certs:/etc/nginx/certs:ro
+    depends_on:
+      - web
 
   db:
     build: ./db

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,55 @@
+limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=upload_limit:10m rate=2r/s;
+
+server {
+    listen 80;
+    return 301 https://$host:8000$request_uri;
+}
+
+server {
+    listen 443 ssl;
+
+    ssl_certificate /etc/nginx/certs/server.crt;
+    ssl_certificate_key /etc/nginx/certs/server.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    client_max_body_size 10M;
+    limit_req_status 429;
+
+    location /login {
+        limit_req zone=login_limit burst=5 nodelay;
+
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location /documents/upload {
+        limit_req zone=upload_limit burst=5 nodelay;
+        client_max_body_size 10M;
+
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location / {
+        limit_req zone=api_limit burst=20 nodelay;
+
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}

--- a/web/run.py
+++ b/web/run.py
@@ -137,5 +137,4 @@ if __name__ == "__main__":
         host="0.0.0.0",
         port=8000,
         debug=True,
-        ssl_context=(str(cert_file), str(key_file)),
     )


### PR DESCRIPTION
- Limitar requests por IP:
  - Limite geral da API: 10 requests/segundo por IP
  - Zona usada: api_limit

- Proteger endpoints críticos:
  - /login: 5 requests/minuto por IP
  - /documents/upload: 2 requests/segundo por IP

- Configurar throttling:
  - /: burst=20 com nodelay
  - /login: burst=5 com nodelay
  - /documents/upload: burst=5 com nodelay

- Limitar tamanho de requests:
  - client_max_body_size 10M
  - Aplicado globalmente e reforçado no endpoint /documents/upload